### PR TITLE
Chosen would fail when being applied to a disabled <select>

### DIFF
--- a/Chosen.js
+++ b/Chosen.js
@@ -771,7 +771,7 @@ define(["dojo/_base/declare",
 				domClass.add(this.container, 'chzn-disabled');
 				domAttr.set(this.search_field, 'disabled', true);
 				if(!this.is_multiple) {
-					if(!this.selected_item_focus_handle) {
+					if(this.selected_item_focus_handle) {
 						this.selected_item_focus_handle.remove();
 					}
 				}


### PR DESCRIPTION
Calling `this.selected_item_focus_handle.remove()` only makes sense if `this.selected_item_focus_handle` exists in the first place. The `if` statement on line 774 had this logic backwards.

This error:
![screen shot 2014-03-26 at 3 05 04 pm](https://cloud.githubusercontent.com/assets/194735/2530016/f7c76a24-b521-11e3-90d0-ee35897890be.PNG)
would appear when applying Chosen to a disabled `select` element.

Simply removing the `!` fixed it right up.
